### PR TITLE
Bump platform building blocks to 3.0.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ resources:
   - repository: das-platform-building-blocks
     type: github
     name: SkillsFundingAgency/das-platform-building-blocks
-    ref: refs/tags/2.1.28
+    ref: refs/tags/3.0.0
     endpoint: SkillsFundingAgency
   - repository: das-platform-automation
     type: github

--- a/pipeline-templates/job/deploy.yml
+++ b/pipeline-templates/job/deploy.yml
@@ -57,7 +57,6 @@ jobs:
             AzureSubscription: ${{ parameters.ServiceConnection }}
             ServerName: $(SharedSQLServerFQDN)
             SqlUsername: $(SharedSQLServerUsername)
-            SqlPassword: $(SharedSQLServerPassword)
             DacpacFile: $(Pipeline.Workspace)/DacpacArtifact/src/${{ parameters.DACPACSolutionBaseName }}/bin/Output/${{ parameters.DACPACSolutionBaseName }}.dacpac
             DatabaseName: $(DatabaseName)
             OverrideBlockOnPossibleDataLoss: ${{ parameters.OverrideBlockOnPossibleDataLoss }}


### PR DESCRIPTION
This PR updates platform build blocks to refs/tags/3.0.0 and removes the SqlPassword param line required to resolve breaking change.